### PR TITLE
feat: Added options page to control hunger update time.

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,25 +1,56 @@
 const MAX_FULLNESS = 30;
-const DECREASE_INTERVAL = 5000;
-let decreaseInterval;
+const MIN_FULLNESS = 15;
+const DEFAULT_DECREASE_INTERVAL = 5000;
 
 console.log("background.js is running");
+
+browser.runtime.onInstalled.addListener(() => {
+    //alarm to trigger every 15 sec to keep the background script from going idle
+    browser.alarms.create('intervalAlarm', { periodInMinutes: 0.25 });
+});
+//listen for alarm
+browser.alarms.onAlarm.addListener((alarm) => {
+    if (alarm.name === 'intervalAlarm') {
+        console.log("15 seconds passed, keeping background alive");
+    }
+});
 
 browser.storage.local.get('fullness').then(result => {
     updatePet(result.fullness || MAX_FULLNESS);
 });
 
-decreaseInterval = setInterval(decreaseFullness, DECREASE_INTERVAL);
+//initialize decreaseInterval Scheduler
+let decreaseInterval;
+browser.storage.local.get('decreaseInterval').then(result => {
+    let decreaseTime = result.decreaseInterval || DEFAULT_DECREASE_INTERVAL;
+    decreaseInterval = setInterval(decreaseFullness, decreaseTime);
+    console.log("Interval timer set to decrease fullness every " + (decreaseTime / 1000) + " seconds.");
+});
 
+//decreasing fullness
 function decreaseFullness() {
     browser.storage.local.get('fullness').then(result => {
-        let fullness = result.fullness || MAX_FULLNESS;
-        fullness = Math.max(5, fullness - 5); // Reduce fullness
-        browser.storage.local.set({ fullness });
-
-        console.log(`fullness decreased in background: ${fullness}`);
+        let fullness = Math.min(result.fullness, MAX_FULLNESS);
+        currentFullness = Math.max(MIN_FULLNESS, fullness - 5); // Reduce fullness
+        browser.storage.local.set({ fullness: currentFullness });
+        console.log(`fullness decreased in background: ${currentFullness}`);
     });
 }
 
+//update stored fullness value
 function updatePet(fullness) {
     browser.storage.local.set({ fullness });
 }
+
+//listen for user's time choice
+browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if (message.action === "resetInterval") {
+        clearInterval(decreaseInterval); //erase old interval
+        browser.storage.local.get('decreaseInterval').then(result => {
+            decreaseTime = result.decreaseInterval || DEFAULT_DECREASE_INTERVAL;
+            decreaseInterval = setInterval(decreaseFullness, decreaseTime);
+            console.log("Interval timer re-intialized to new seconds value:", result.decreaseInterval);
+        });
+    }
+    return Promise.resolve();
+});

--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,11 @@
     "default_icon": "assets/icons/icon128.png"
   },
   "permissions": [
-    "storage"
-  ]
+    "storage",
+    "alarms"
+  ],
+  "options_ui": {
+        "page": "options.html",
+        "open_in_tab": true
+    }
 }

--- a/options.css
+++ b/options.css
@@ -1,0 +1,75 @@
+/* 
+general styles
+*/
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f4f7fc;
+    color: #333;
+    margin: 0;
+    padding: 20px;
+}
+
+h2 {
+    text-align: center;
+    font-size: 2.5em;
+    color: #4A90E2;
+    margin-bottom: 20px;
+}
+
+h3 {
+    font-size: 1.8em;
+    color: #333;
+}
+
+h4 {
+    font-size: 1.2em;
+    color: #555;
+}
+
+/*
+input and button styles
+*/
+input[type="text"] {
+    padding: 10px;
+    margin-top: 10px;
+    width: 100%;
+    max-width: 300px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 1em;
+}
+
+input[type="text"]:focus {
+    border-color: #4A90E2;
+    outline: none;
+    box-shadow: 0 0 5px rgba(74, 144, 226, 0.5);
+}
+
+button {
+    padding: 10px 20px;
+    background-color: #4A90E2;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    font-size: 1.2em;
+    cursor: pointer;
+    margin-top: 20px;
+    transition: background-color 0.3s ease;
+}
+
+button:hover {
+    background-color: #357ABD;
+}
+
+button:focus {
+    outline: none;
+}
+
+/* 
+submit message styling 
+*/
+#confirmationMessage {
+    margin-top: 20px;
+    text-align: center;
+    font-size: 1.3em;
+}

--- a/options.html
+++ b/options.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <title>Pet Options</title>
+    <link rel="stylesheet" type="text/css" href="options.css"/>
+</head>
+<body>
+    <h2>Pet Options</h2>
+        <h3>Time Until Hungry:</h3>
+        <h4>Input a seconds value. Your pet will take this long to go from too full to hungry. </h4>
+        <label for="userInput"></label>
+        <input type="text" id="userInput" name="userInput" placeholder="10...">
+        <button id="submitButton">Submit</button>
+
+        <p id="confirmationMessage" style="color: rgb(23, 129, 211); font-weight: bold;"></p>
+
+        <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,22 @@
+document.addEventListener("DOMContentLoaded", function () {
+    document.getElementById("submitButton").addEventListener("click", function () {
+        let inputValue = document.getElementById("userInput").value;
+        let message = document.getElementById("confirmationMessage");
+
+        if (isNaN(inputValue) || inputValue.trim() === "") {
+            message.style.color = "red";
+            message.textContent = "Please enter a number!";
+        } else {
+            message.style.color = "rgb(23, 129, 211)";
+            message.textContent = "Your pet will get hungry after " + inputValue + " seconds.";
+            browser.storage.local.set({ decreaseInterval: (parseInt(inputValue) * 1000 / 3) }).then( (result) => {
+                console.log("Seconds value set in storage to",(parseInt(inputValue) * 1000 / 3));
+
+                browser.runtime.sendMessage({ action: "resetInterval" }).catch(error => {
+                        console.error("Error sending message:", error);
+                    });
+                }
+            );
+        }
+    });
+});

--- a/popup.js
+++ b/popup.js
@@ -2,7 +2,8 @@ const MAX_FULLNESS = 30;
 const MIN_FULLNESS = 15;
 const DECREASE_FULLNESS_BY = 5;
 const INCREASE_FULLNESS_BY = 5;
-const DECREASE_INTERVAL = 5000; // 5 seconds in milliseconds
+const DEFAULT_DECREASE_INTERVAL = 5000; // 5 seconds in milliseconds
+const CHECK_FULLNESS_INTERVAL = 2000 // 2 seconds in milliseconds
 
 
 const catStates = {
@@ -45,13 +46,12 @@ function getPetStates(chosenPet) {
     return chosenPet === 'panda' ? pandaStates : catStates;
 }
 
-let decreaseInterval;
+let fullnessCheckInterval;
 
 document.addEventListener('DOMContentLoaded', () => {
     const feedButton = document.getElementById('feed');
     const petSelect = document.getElementById('petSelect');
 
-   
     browser.storage.local.get(['chosenPet', 'fullness']).then(result => {
         // If no chosen pet, default to "cat"
         const chosenPet = result.chosenPet || 'cat';
@@ -68,10 +68,8 @@ document.addEventListener('DOMContentLoaded', () => {
         updatePet(currentFullness);
     });
 
-    
-    decreaseInterval = setInterval(decreaseFullness, DECREASE_INTERVAL);
+    fullnessCheckInterval = setInterval(checkFullness, CHECK_FULLNESS_INTERVAL);
 
-    
     petSelect.addEventListener('change', () => {
         const newPet = petSelect.value;
         
@@ -83,16 +81,24 @@ document.addEventListener('DOMContentLoaded', () => {
             updatePet(fullness);
         });
     });
-
-    
+ 
     if (feedButton) {
         feedButton.addEventListener('click', feed);
     }
 });
 
+function checkFullness() {
+    browser.storage.local.get('fullness').then(result => {
+        let currentFullness = result.fullness || MAX_FULLNESS;
+        updatePet(currentFullness);
+    });
+}
+
 function updatePet(fullness) {
     const petImage = document.getElementById("pet");
     const statusText = document.getElementById("status");
+
+    console.log("Updating pet - Fullness =", fullness);
 
     
     let mood = "happy";
@@ -110,16 +116,6 @@ function updatePet(fullness) {
 
         petImage.src = petStates[mood].img;
         statusText.textContent = petStates[mood].text;
-    });
-}
-
-function decreaseFullness() {
-    browser.storage.local.get('fullness').then(result => {
-        let currentFullness = result.fullness || MAX_FULLNESS;
-        currentFullness = Math.max(MIN_FULLNESS, currentFullness - DECREASE_FULLNESS_BY);
-
-        browser.storage.local.set({ fullness: currentFullness });
-        updatePet(currentFullness);
     });
 }
 


### PR DESCRIPTION
Response to Feature Request #14.

I added an options page (accessible from the "preferences" selection in the manage extensions window) where you can set the time until you pet gets hungry. The selection on that page will update a variable in the browser storage and set an interval in background.js to the given time frame. The options page is complete with CSS styling.

I also cleaned up some seemingly vestigial code in popup.js.